### PR TITLE
New destination: an internal server

### DIFF
--- a/etl/database.py
+++ b/etl/database.py
@@ -44,7 +44,8 @@ class DbDestination(object):
   def __init__(self, params):
     self.params = params
 
+
   def insert(self):
-    source_df = pg_to_df('pnc', 'escrow')
+    source_df = pg_to_df(self.params['schema'], self.params['table'])
     destination_engine = sqlalchemy.create_engine(make_db_connection_string(self.params['dbType'], self.params['prefix']))
     source_df.to_sql(self.params['destination'], destination_engine, if_exists=self.params['if_exists'], index=False)

--- a/etl/database.py
+++ b/etl/database.py
@@ -3,7 +3,7 @@ import cx_Oracle
 import pandas
 import odo
 from os import environ as env
-from etl.utils import df_to_pg
+from etl.utils import df_to_pg, pg_to_df
 
 def get_table_as_df(query, connString):
   engine = sqlalchemy.create_engine(connString)
@@ -39,3 +39,12 @@ class DbTable(object):
     self.conn = make_db_connection_string(self.dbType, self.prefix)
     self.df = get_table_as_df(self.query_all, self.conn)
     df_to_pg(self.df, self.schema, self.table)
+
+class DbDestination(object):
+  def __init__(self, params):
+    self.params = params
+
+  def insert(self):
+    source_df = pg_to_df('pnc', 'escrow')
+    destination_engine = sqlalchemy.create_engine(make_db_connection_string(self.params['dbType'], self.params['prefix']))
+    source_df.to_sql(self.params['destination'], destination_engine, if_exists=self.params['if_exists'], index=False)

--- a/etl/process.py
+++ b/etl/process.py
@@ -86,6 +86,8 @@ class Process(object):
           a = AirtableTable(params)
           drop_table_if_exists(connection, params['destination'])
           a.to_postgres()
+
+
           
         else:
           print("I don't know this source type: {}".format(srctype))
@@ -152,6 +154,11 @@ class Process(object):
           from .mapbox import MapboxUpload
           m = MapboxUpload(d)
           m.upload()
+
+        elif destination == 'internal':
+          from .database import DbDestination
+          dest = DbDestination(d)
+          dest.insert()
 
         else:
           print("I don't know this destination type: {}".format(destination))

--- a/etl/sftp.py
+++ b/etl/sftp.py
@@ -63,15 +63,17 @@ class Sftp(object):
     elif self.host == 'pnc':
       cnopts = pysftp.CnOpts()
       cnopts.hostkeys = None
-      with pysftp.Connection(env['MOVEIT_HOST'], port=22, username=env['MOVEIT_USER'], password=env['MOVEIT_PASS'], cnopts=cnopts) as sftp:
-        print('connected to {}'.format(env['MOVEIT_HOST']))
+      with pysftp.Connection(env['MOVEITPROD_HOST'], port=22, username=env['MOVEITPROD_USER'], password=env['MOVEITPROD_PASS'], cnopts=cnopts) as sftp:
+        print('connected to {}'.format(env['MOVEITPROD_HOST']))
 
-        file_name = 'TrialBalance07192018_TEST.xlsx'
+        import arrow
+        date = arrow.utcnow().shift(days=-1)
+        file_name = "TrialBalance{}.csv".format(date.format('MMDDYYYY'))
         path = '/Home/IET/PNC/' + file_name
           
         if sftp.isfile(path):
           sftp.get(path, preserve_mtime=True)
-          self.df = pandas.read_excel(file_name)
+          self.df = pandas.read_csv(file_name)
           rename_cols(self.df)
           os.remove(file_name)
           print('got file, read into df')

--- a/etl/sftp.py
+++ b/etl/sftp.py
@@ -5,6 +5,7 @@ from .utils import df_to_pg
 
 def clean_cols(name):
   name = name.replace(":", "")
+  name = name.replace("#", "")
   name = name.replace(" ", "_").lower().strip()
   return name
 
@@ -52,6 +53,25 @@ class Sftp(object):
         if sftp.isfile(path):
           sftp.get(path, preserve_mtime=True)
           self.df = pandas.read_csv(file_name)
+          rename_cols(self.df)
+          os.remove(file_name)
+          print('got file, read into df')
+        else:
+          print('No file named {} found.'.format(file_name))
+          pass
+  
+    elif self.host == 'pnc':
+      cnopts = pysftp.CnOpts()
+      cnopts.hostkeys = None
+      with pysftp.Connection(env['MOVEIT_HOST'], port=22, username=env['MOVEIT_USER'], password=env['MOVEIT_PASS'], cnopts=cnopts) as sftp:
+        print('connected to {}'.format(env['MOVEIT_HOST']))
+
+        file_name = 'TrialBalance07192018_TEST.xlsx'
+        path = '/Home/IET/PNC/' + file_name
+          
+        if sftp.isfile(path):
+          sftp.get(path, preserve_mtime=True)
+          self.df = pandas.read_excel(file_name)
           rename_cols(self.df)
           os.remove(file_name)
           print('got file, read into df')

--- a/etl/utils.py
+++ b/etl/utils.py
@@ -22,6 +22,12 @@ def df_to_pg(df, schema, table):
   import odo
   odo.odo(df, 'postgresql://{}/{}::{}'.format(env['PG_CONNSTR'], env['PG_DB'], table), schema=schema)
 
+def pg_to_df(schema, table):
+  import pandas
+  import sqlalchemy
+  eng = sqlalchemy.create_engine("postgresql://{}/{}".format(env['PG_CONNSTR'], env['PG_DB']))
+  return pandas.read_sql("select * from {}.{}".format(schema, table), eng)
+
 def connect_to_pg():
   engine = sqlalchemy.create_engine('postgresql+psycopg2://{}/{}'.format(env['PG_CONNSTR'], env['PG_DB']))
   connection = engine.connect()

--- a/process/escrow/00_metadata.yml
+++ b/process/escrow/00_metadata.yml
@@ -1,0 +1,3 @@
+name:
+schema:
+notify:

--- a/process/escrow/01_extract.yml
+++ b/process/escrow/01_extract.yml
@@ -1,0 +1,3 @@
+- sftp:
+    host: pnc
+    destination: pnc.escrow

--- a/process/escrow/02_transform.yml
+++ b/process/escrow/02_transform.yml
@@ -1,0 +1,12 @@
+- type: sql
+  statements:
+    - delete from pnc.escrow where master_account is null
+    - delete from pnc.escrow where master_account = 'NaN'
+    - alter table pnc.escrow alter column master_account type bigint using master_account::bigint
+    - alter table pnc.escrow rename column master_account to master_account_num
+    - alter table pnc.escrow alter column sub_account_ type bigint using sub_account_::bigint
+    - alter table pnc.escrow rename column sub_account_ to sub_account_num
+    - alter table pnc.escrow rename column group_ to group_num
+    - alter table pnc.escrow rename column item_ to item_num
+    - alter table pnc.escrow rename column fed_wh_tax_this_period to fed_withholding_tax_this_period
+    - alter table pnc.escrow rename column ytd_fed_wh_tax to ytd_fed_withholding_tax

--- a/process/escrow/03_load.yml
+++ b/process/escrow/03_load.yml
@@ -1,0 +1,6 @@
+- to: internal
+  prefix: ESCROW
+  dbType: sql-server
+  source: pnc.escrow
+  destination: property_data_escrowbalance
+  if_exists: append

--- a/process/project_greenlight/01_extract.yml
+++ b/process/project_greenlight/01_extract.yml
@@ -1,3 +1,6 @@
 - smartsheet: 
     id: 2432809366251396
     table: greenlight
+- smartsheet: 
+    id: 4058809057470340
+    table: applications

--- a/process/project_greenlight/02_transform.yml
+++ b/process/project_greenlight/02_transform.yml
@@ -1,5 +1,7 @@
 - type: sql
   statements:
+    - drop table pubsafe.greenlight_unanon cascade;
+    - create table pubsafe.greenlight_unanon as select * from pubsafe.greenlight
     - delete from pubsafe.greenlight where status is null;
     - delete from pubsafe.greenlight where status in ('Red', 'Yellow');
 
@@ -33,3 +35,8 @@
             geom
           from pubsafe.greenlight where trim(status) = 'Green' and geom is not null )
     
+
+- type: sql
+  statements: 
+    - update pubsafe.applications set let_us_know_why_you_are_interested_in_joining = replace(let_us_know_why_you_are_interested_in_joining, '''', '')
+    - update pubsafe.applications set is_there_anything_additional_we_should_know = replace(is_there_anything_additional_we_should_know, '''', '')

--- a/process/project_greenlight/03_load.yml
+++ b/process/project_greenlight/03_load.yml
@@ -8,21 +8,37 @@
 #     - police
 #     - opendata
 #     - greenlight
-- to: Socrata
-  columns:
-    Address:
-      field: address
-      type: text
-    Business Name:
-      field: business_name
-      type: text
-    Live Date:
-      field: live_date
-      type: calendar_date
-    Location:
-      field: location
-      type: location
-  id: vrh6-6pvj
-  name: Project Greenlight Locations
-  table: pubsafe.greenlight_socrata
-  method: replace
+- to: internal
+  prefix: CRIMEINCIDENTS
+  dbType: sql-server
+  schema: pubsafe
+  table: applications
+  destination: project_greenlight_applications
+  if_exists: replace
+  name: Project Greenlight Applications
+- to: internal
+  prefix: CRIMEINCIDENTS
+  dbType: sql-server
+  schema: pubsafe
+  table: greenlight_unanon
+  destination: project_greenlight_master
+  if_exists: replace
+  name: Project Greenlight Master
+# - to: Socrata
+#   columns:
+#     Address:
+#       field: address
+#       type: text
+#     Business Name:
+#       field: business_name
+#       type: text
+#     Live Date:
+#       field: live_date
+#       type: calendar_date
+#     Location:
+#       field: location
+#       type: location
+#   id: vrh6-6pvj
+#   name: Project Greenlight Locations
+#   table: pubsafe.greenlight_socrata
+#   method: replace


### PR DESCRIPTION
Pulling this functionality over to `dev`:

we have a new class in `database.py`: `DbDestination`

credentials are stored normally with a `prefix`

this class reads an `etl` table as a dataframe and then uses pandas `to_sql` method to replace or append as needed (this is in the `if_exists` param)

and then there is a small example using the `escrow` process!
